### PR TITLE
Use npm link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install -g yo
 To install generator-magentomodule from npm, run:
 
 ```
-$ npm install -g generator-magentomodule
+$ npm link
 ```
 
 Finally, initiate the generator from your Magento root directory:


### PR DESCRIPTION
The old instructions will install the wrong module.
